### PR TITLE
Remove max_size parameter

### DIFF
--- a/examples/gizmo_tft_demo.py
+++ b/examples/gizmo_tft_demo.py
@@ -14,7 +14,7 @@ from adafruit_gizmo import tft_gizmo
 display = tft_gizmo.TFT_Gizmo()
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(240, 240, 1)
@@ -32,7 +32,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=2, x=50, y=120)
+text_group = displayio.Group(scale=2, x=50, y=120)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/gizmo_tft_thermometer.py
+++ b/examples/gizmo_tft_thermometer.py
@@ -56,7 +56,7 @@ with open("/thermometer_background.bmp", "rb") as bitmap_file:
     text = "%.2f C" % (round(cp.temperature, 2))
 
     # Create a Group for the text so we can scale it
-    text_group = displayio.Group(max_size=1, scale=TEXT_SCALE, x=0, y=0)
+    text_group = displayio.Group(scale=TEXT_SCALE, x=0, y=0)
 
     # Create a Label to show the initial temperature value
     text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-st7789

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "Adafruit-Blinka",
         "adafruit-circuitpython-busdevice",
-        "adafruit_st7789",
+        "adafruit-circuitpython-st7789",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Correct the requirements for st7789 - Closes #16 

I don't have a Gizmo to test with.