### PR TITLE
Update the pixel_shader usage of OnDiskBitmap

### DIFF
--- a/examples/gizmo_eink_simpletest.py
+++ b/examples/gizmo_eink_simpletest.py
@@ -16,12 +16,13 @@ display_group = displayio.Group()
 with open("/display-ruler.bmp", "rb") as file:
     picture = displayio.OnDiskBitmap(file)
     # Create a Tilegrid with the bitmap and put in the displayio group
+    # CircuitPython 6 & 7 compatible
     sprite = displayio.TileGrid(
         picture,
         pixel_shader=getattr(picture, "pixel_shader", displayio.ColorConverter()),
-        # TODO: Once CP6 is no longer supported, replace the above line with below
-        # pixel_shader=picture.pixel_shader,
     )
+    # CircuitPython 7 compatible only
+    # sprite = displayio.TileGrid(picture, pixel_shader=bitmap.pixel_shader)
     display_group.append(sprite)
 
     # Place the display group on the screen

--- a/examples/gizmo_eink_simpletest.py
+++ b/examples/gizmo_eink_simpletest.py
@@ -16,7 +16,12 @@ display_group = displayio.Group()
 with open("/display-ruler.bmp", "rb") as file:
     picture = displayio.OnDiskBitmap(file)
     # Create a Tilegrid with the bitmap and put in the displayio group
-    sprite = displayio.TileGrid(picture, pixel_shader=displayio.ColorConverter())
+    sprite = displayio.TileGrid(
+        picture,
+        pixel_shader=getattr(picture, "pixel_shader", displayio.ColorConverter()),
+        # TODO: Once CP6 is no longer supported, replace the above line with below
+        # pixel_shader=picture.pixel_shader,
+    )
     display_group.append(sprite)
 
     # Place the display group on the screen

--- a/examples/gizmo_tft_thermometer.py
+++ b/examples/gizmo_tft_thermometer.py
@@ -44,7 +44,12 @@ with open("/thermometer_background.bmp", "rb") as bitmap_file:
     bitmap = displayio.OnDiskBitmap(bitmap_file)
 
     # Create a TileGrid to hold the bitmap
-    tile_grid = displayio.TileGrid(bitmap, pixel_shader=displayio.ColorConverter())
+    tile_grid = displayio.TileGrid(
+        bitmap,
+        pixel_shader=getattr(bitmap, "pixel_shader", displayio.ColorConverter()),
+        # TODO: Once CP6 is no longer supported, replace the above line with below
+        # pixel_shader=bitmap.pixel_shader,
+    )
 
     # Create a Group to hold the TileGrid
     group = displayio.Group()

--- a/examples/gizmo_tft_thermometer.py
+++ b/examples/gizmo_tft_thermometer.py
@@ -44,12 +44,13 @@ with open("/thermometer_background.bmp", "rb") as bitmap_file:
     bitmap = displayio.OnDiskBitmap(bitmap_file)
 
     # Create a TileGrid to hold the bitmap
+    # CircuitPython 6 & 7 compatible
     tile_grid = displayio.TileGrid(
         bitmap,
         pixel_shader=getattr(bitmap, "pixel_shader", displayio.ColorConverter()),
-        # TODO: Once CP6 is no longer supported, replace the above line with below
-        # pixel_shader=bitmap.pixel_shader,
     )
+    # CircuitPython 7 compatible only
+    # tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
 
     # Create a Group to hold the TileGrid
     group = displayio.Group()


### PR DESCRIPTION
OnDiskBitmap has had incompatible changes in `7.0.0-alpha.3` - Ref: https://github.com/adafruit/circuitpython/pull/4823
This PR is part of a group of updates for this change - https://github.com/adafruit/circuitpython/issues/4982

This PR updates the library to the combined usage for CP6 & CP7 with a TODO to remove the CP6 compatibility in the future. It has not been tested as I do not have the hardware.